### PR TITLE
Avoid redefining the VERSION constant.

### DIFF
--- a/lib/http/accept.rb
+++ b/lib/http/accept.rb
@@ -18,8 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require "http/accept/version"
-
 require_relative 'accept/version'
 
 # Accept: header


### PR DESCRIPTION
Currently there is a warning due to double requiring the version file
and defining the VERSION constant twice.

    ~/.rbenv/gems/2.3.0/gems/http-accept-1.7.0/lib/http/accept/version.rb:23:
    warning: already initialized constant HTTP::Accept::VERSION
    ~/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/http-accept-1.7.0/lib/http/accept/version.rb:23:
    warning: previous definition of VERSION was here